### PR TITLE
Fix AttributeError: 'HomeAssistant' object has no attribute 'request'

### DIFF
--- a/custom_components/innotemp/__init__.py
+++ b/custom_components/innotemp/__init__.py
@@ -4,6 +4,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import InnotempApiClient
 from .coordinator import InnotempDataUpdateCoordinator
@@ -23,7 +24,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data["username"]
     password = entry.data["password"]
 
-    api_client = InnotempApiClient(hass, host, username, password)
+    session = async_get_clientsession(hass)
+    api_client = InnotempApiClient(session, host, username, password)
 
     # Login and fetch initial configuration
     try:


### PR DESCRIPTION
The InnotempApiClient was being initialized with the HomeAssistant object (`hass`) instead of an aiohttp.ClientSession. This caused an AttributeError when the client tried to make HTTP calls using `hass.request` which does not exist.

This commit updates `custom_components/innotemp/__init__.py` to:
1. Import `async_get_clientsession` from `homeassistant.helpers.aiohttp_client`.
2. Obtain an `aiohttp.ClientSession` using `async_get_clientsession(hass)`.
3. Pass this session to the `InnotempApiClient` constructor.

This ensures that the API client uses the correct session object for making HTTP requests, resolving the AttributeError.