### PR TITLE
Fix 500 error on Innotemp config flow load

### DIFF
--- a/custom_components/innotemp/config_flow.py
+++ b/custom_components/innotemp/config_flow.py
@@ -16,27 +16,6 @@ from . import PLATFORMS  # Import PLATFORMS from __init__.py
 _LOGGER = logging.getLogger(__name__)
 
 
-def _validate_host_input(host_input: str) -> str:
-    if not host_input:
-        raise vol.Invalid("Host cannot be empty.")
-    if host_input.lower() in ["http", "https"]:
-        raise vol.Invalid("Hostname cannot be 'http' or 'https'. Enter a valid IP address or hostname.")
-    if "://" in host_input:
-        raise vol.Invalid("Hostname should not include '://'. Enter just the address.")
-    if len(host_input) < 3: # Basic length check, e.g., "a.b" is too short for a valid TLD host
-        raise vol.Invalid("Hostname is too short or invalid format.")
-    return host_input
-
-
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required("host"): _validate_host_input,
-        vol.Required("username"): str,
-        vol.Required("password"): str,
-    }
-)
-
-
 class InnotempConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Innotemp Heating Controller."""
 
@@ -44,6 +23,27 @@ class InnotempConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
+        errors = {}
+
+        def _validate_host_input(host_input: str) -> str:
+            if not host_input:
+                raise vol.Invalid("Host cannot be empty.")
+            if host_input.lower() in ["http", "https"]:
+                raise vol.Invalid("Hostname cannot be 'http' or 'https'. Enter a valid IP address or hostname.")
+            if "://" in host_input:
+                raise vol.Invalid("Hostname should not include '://'. Enter just the address.")
+            if len(host_input) < 3: # Basic length check, e.g., "a.b" is too short for a valid TLD host
+                raise vol.Invalid("Hostname is too short or invalid format.")
+            return host_input
+
+        data_schema = vol.Schema(
+            {
+                vol.Required("host"): _validate_host_input,
+                vol.Required("username"): str,
+                vol.Required("password"): str,
+            }
+        )
+
         if user_input is not None:
             # Basic validation: Try to connect
             session = async_get_clientsession(self.hass)
@@ -61,14 +61,15 @@ class InnotempConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except Exception as ex:
                 _LOGGER.error("Failed to connect to Innotemp: %s", ex)
+                errors["base"] = "cannot_connect"
                 # Show an error form if connection fails
                 return self.async_show_form(
                     step_id="user",
-                    data_schema=DATA_SCHEMA,
-                    errors={"base": "cannot_connect"},
+                    data_schema=data_schema,
+                    errors=errors,
                 )
 
-        return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
 
 
 async def async_setup_entry(


### PR DESCRIPTION
This commit resolves a "500 Internal Server Error" that occurred when you attempted to load the Innotemp integration's config flow.

The primary change is in `custom_components/innotemp/config_flow.py`:
- The data validation schema (previously `DATA_SCHEMA` at module level) and its custom host validator function (`_validate_host_input`) are now defined locally within the `async_step_user` method.

This change defers the schema compilation until the `async_step_user` method is actually invoked, which can prevent issues that arise from module-level schema processing during Home Assistant's initial loading of the config flow module.

The `errors` dictionary is also explicitly initialized and passed to `async_show_form` to ensure proper display of both field-specific validation errors and general connection errors.

The existing fixes for host validation logic and correct `InnotempApiClient` initialization (using an `aiohttp.ClientSession`) within `async_step_user` are maintained.