### PR TITLE
Fix: Call synchronous SSE callback correctly

### DIFF
--- a/custom_components/innotemp/api.py
+++ b/custom_components/innotemp/api.py
@@ -237,25 +237,14 @@ class InnotempApiClient:
 
                                     if callback is None:
                                         _LOGGER.error("SSE callback is None. Cannot process data.")
+                                    elif not callable(callback):
+                                        _LOGGER.error(
+                                            "SSE callback is not callable. Type: %s. Cannot process data.",
+                                            type(callback)
+                                        )
                                     else:
-                                        is_valid_awaitable_callable = False
-                                        if asyncio.iscoroutinefunction(callback):
-                                            is_valid_awaitable_callable = True
-                                        elif hasattr(callback, '__func__') and asyncio.iscoroutinefunction(callback.__func__):
-                                            # This handles bound methods of async def functions
-                                            is_valid_awaitable_callable = True
-
-                                        if is_valid_awaitable_callable:
-                                            await callback(processed_data)
-                                        else:
-                                            # This case should ideally not be reached if type hints are followed,
-                                            # but it's a safeguard.
-                                            # The error "TypeError: object NoneType can't be used in 'await' expression"
-                                            # would occur if callback is a sync function returning None.
-                                            _LOGGER.error(
-                                                "SSE callback is not a recognized awaitable coroutine function or bound method. Type: %s. Cannot process data.",
-                                                type(callback)
-                                            )
+                                        # Corrected: async_set_updated_data is synchronous
+                                        callback(processed_data)
                             except (json.JSONDecodeError, IndexError) as e:
                                 _LOGGER.warning("Error processing SSE data line: %s", e)
 


### PR DESCRIPTION
Previous attempts to fix the SSE callback invocation were based on the incorrect assumption that `DataUpdateCoordinator.async_set_updated_data` was an `async def` method. It has been confirmed that this method is synchronous (decorated with `@callback`).

This commit corrects the invocation in `api.py`'s `sse_listener` from `await callback(processed_data)` to a direct synchronous call: `callback(processed_data)`.

The validation logic for the callback has also been simplified to check if it's not None and is callable, which is appropriate for a synchronous method.

This resolves the `TypeError: object NoneType can't be used in 'await' expression'` that would occur from awaiting a synchronous function returning None, and also removes the erroneous validation errors produced by previous checks that incorrectly expected an async function.