### PR TITLE
Fix: Resolve via_device warning and sensor NameError

### DIFF
--- a/custom_components/innotemp/coordinator.py
+++ b/custom_components/innotemp/coordinator.py
@@ -91,7 +91,7 @@ class InnotempCoordinatorEntity(CoordinatorEntity):
                     component_stable_id_part = _local_slugify(comp_label) # Use local slugify
 
                 if component_stable_id_part: # Ensure we have something to make it unique
-                    device_identifiers = {(DOMAIN, self._config_entry.unique_id, room_var, component_stable_id_part)}
+                    device_identifiers = {(DOMAIN, self._config_entry.entry_id, room_var, component_stable_id_part)}
                     device_name = comp_label or f"{room_label} - {component_stable_id_part}"
                     device_model = comp_type or "Component"
 
@@ -100,21 +100,21 @@ class InnotempCoordinatorEntity(CoordinatorEntity):
                         "name": device_name,
                         "manufacturer": "Innotemp",
                         "model": device_model,
-                        "via_device": (DOMAIN, self._config_entry.unique_id, room_var),
+                        "via_device": (DOMAIN, self._config_entry.entry_id, room_var),
                     }
 
             # Fallback to room-level device if no specific component info or component_stable_id_part is missing
             return {
-                "identifiers": {(DOMAIN, self._config_entry.unique_id, room_var)},
+                "identifiers": {(DOMAIN, self._config_entry.entry_id, room_var)},
                 "name": room_label,
                 "manufacturer": "Innotemp",
                 "model": room_type,
-                "via_device": (DOMAIN, self._config_entry.unique_id), # Main controller device
+                "via_device": (DOMAIN, self._config_entry.entry_id), # Main controller device
             }
 
         # Default device for the whole integration if no specific room/component attributes are found
         return {
-            "identifiers": {(DOMAIN, self._config_entry.unique_id)},
+            "identifiers": {(DOMAIN, self._config_entry.entry_id)},
             "name": "Innotemp Heating Controller", # Main controller device name
             "manufacturer": "Innotemp",
         }

--- a/custom_components/innotemp/sensor.py
+++ b/custom_components/innotemp/sensor.py
@@ -297,7 +297,7 @@ class InnotempSensor(InnotempCoordinatorEntity, SensorEntity):
         # _attr_unique_id is also set by InnotempCoordinatorEntity
         # self._attr_unique_id = f"{config_entry.unique_id}_{param_id}"
 
-        self._attr_native_unit_of_measurement = param_data.get("unit")
+        self._attr_native_unit_of_measurement = self._param_data.get("unit") # Use self._param_data
         self._param_id = param_id # Store the 'var' to fetch data from coordinator
 
         # Attempt to map units to device classes or set state class


### PR DESCRIPTION
This commit addresses two issues observed during integration setup:

1.  **`via_device` warning and incorrect device linking**:
    -   The warning `Detected that custom integration 'innotemp' calls device_registry.async_get_or_create referencing a non existing via_device` was occurring because `config_entry.unique_id` could be `None`, leading to invalid device identifiers used in `via_device` tuples.
    -   Modified `InnotempCoordinatorEntity.device_info` in `coordinator.py` to consistently use `self._config_entry.entry_id` (which is guaranteed non-None for a loaded entry) instead of `self._config_entry.unique_id` for all parts of device identifiers (in `identifiers` and `via_device` tuples).
    -   This ensures that parent devices are created with stable, valid identifiers before child devices attempt to link to them, resolving the warning and ensuring correct device hierarchy and entity nesting.

2.  **`NameError` in `InnotempSensor.__init__`**:
    -   A `NameError: name 'param_data' is not defined` occurred in `sensor.py` because a variable was renamed to `sensor_data` during a previous refactor, but one instance (`param_data.get("unit")`) was not updated.
    -   Corrected this by changing `param_data.get("unit")` to `self._param_data.get("unit")` (as `sensor_data` is stored in `self._param_data`).

These fixes should lead to correct device registration, proper linking of entities to their parent devices, and successful initialization of sensor entities.