### PR TITLE
Fix(innotemp): Handle missing val_prev and improve logging for value.…

### DIFF
--- a/custom_components/innotemp/api.py
+++ b/custom_components/innotemp/api.py
@@ -184,10 +184,10 @@ class InnotempApiClient:
         if val_prev is not None:
             command_data["val_prev"] = str(val_prev)
         else:
-            # If val_prev is None, we omit it.
-            # Alternatively, the API might expect an empty string or a specific sentinel.
-            # Omitting is often safer if the API treats missing params as "don't care" or "use default".
-            _LOGGER.debug(f"val_prev is None for param {param}, omitting from command.")
+            command_data["val_prev"] = ""  # Send empty string if None
+            _LOGGER.debug(f"val_prev was None for param {param}, sending empty string for val_prev.")
+
+        _LOGGER.debug(f"Sending command to value.save.php with payload: {command_data}")
 
         result = await self._execute_with_retry(
             "POST", "value.save.php", data=command_data
@@ -198,7 +198,7 @@ class InnotempApiClient:
             )
             return True
         _LOGGER.error(
-            f"Failed to send command for room {room_id}: {param} -> {val_new}. Response: {result}"
+            f"Failed to send command for room {room_id}: {param} -> {val_new}. Payload sent: {command_data}. Response: {result}"
         )
         return False
 


### PR DESCRIPTION
…save.php

- Ensures `val_prev` is always sent to `value.save.php`, using an empty string if the previous value is unknown.
- Adds debug logging for the request payload to `value.save.php`.
- Adds error logging for the request payload if the command fails, to aid in diagnosing API access issues.