### PR TITLE
Fix settings/control write path (toggles, selects, numbers)

### DIFF
--- a/custom_components/innotemp/number.py
+++ b/custom_components/innotemp/number.py
@@ -14,7 +14,7 @@ from homeassistant.const import UnitOfTemperature, PERCENTAGE  # For units
 
 from .const import DOMAIN
 from .coordinator import InnotempDataUpdateCoordinator, InnotempCoordinatorEntity
-from .api_parser import strip_html, process_room_config_data
+from .api_parser import strip_html, process_room_config_data, extract_numeric_room_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -191,7 +191,17 @@ class InnotempNumber(InnotempCoordinatorEntity, NumberEntity):
         }
         super().__init__(coordinator, config_entry, entity_config)
 
-        self._api_room_id = room_attributes.get("var")  # For API calls
+        # The value.save.php endpoint expects the *numeric* room id (e.g. 3),
+        # not the room's string ``var`` (e.g. "room3_param1"). Sending the var
+        # caused every number write to be rejected by the controller.
+        self._api_room_id = extract_numeric_room_id(room_attributes)
+        if self._api_room_id is None:
+            _LOGGER.warning(
+                "InnotempNumber %s: could not determine numeric room id from %s; "
+                "value changes may be rejected by the controller.",
+                self._param_id,
+                room_attributes,
+            )
         self._attr_native_unit_of_measurement = self._param_data.get("unit")
 
         # Set device class and default min/max/step based on unit
@@ -273,6 +283,11 @@ class InnotempNumber(InnotempCoordinatorEntity, NumberEntity):
                 _LOGGER.info(
                     f"Successfully sent command for {self.entity_id} to set value to {value}."
                 )
+                # Optimistically reflect the new value immediately so the UI does
+                # not snap back while waiting for the next SSE push.
+                if self.coordinator.data is not None:
+                    self.coordinator.data[self._param_id] = value
+                self.async_write_ha_state()
                 await self.coordinator.async_request_refresh()
             else:
                 _LOGGER.error(

--- a/custom_components/innotemp/select.py
+++ b/custom_components/innotemp/select.py
@@ -217,15 +217,27 @@ class InnotempInputSelect(InnotempCoordinatorEntity, SelectEntity):
         new_api_value = ONOFFAUTO_OPTION_TO_API_VALUE[option]
         previous_api_value: Any | None = None
 
-        # Get the last known value
-        state_var = self.coordinator.control_to_state_map.get(self._param_id)
-        if state_var and self.coordinator.data:
-            previous_api_value = self.coordinator.data.get(state_var)
+        # Get the last known value. The controller validates ``val_prev`` against
+        # the parameter's *current* value (optimistic locking), so it must be read
+        # from this entity's own ``param_id`` -- the same var ``current_option``
+        # displays. Previously this used the *mapped state var* from
+        # ``control_to_state_map``, a different (and often empty) signal, so the
+        # first ``val_prev`` was wrong and the change was silently dropped.
+        if self.coordinator.data:
+            previous_api_value = self.coordinator.data.get(self._param_id)
+            if previous_api_value is None:
+                state_var = self.coordinator.control_to_state_map.get(self._param_id)
+                if state_var:
+                    previous_api_value = self.coordinator.data.get(state_var)
 
-        # Build the list of previous values to try
+        # Build the list of previous values to try, normalising the current value
+        # to its integer API form so the first attempt carries the correct prev.
         val_prev_options = []
         if previous_api_value is not None:
-            val_prev_options.append(previous_api_value)
+            try:
+                val_prev_options.append(int(previous_api_value))
+            except (ValueError, TypeError):
+                val_prev_options.append(previous_api_value)
 
         # Add all possible enum values, ensuring the last known is first.
         for val in ONOFFAUTO_OPTION_TO_API_VALUE.values():
@@ -252,6 +264,11 @@ class InnotempInputSelect(InnotempCoordinatorEntity, SelectEntity):
                 _LOGGER.info(
                     f"Successfully sent command for {self.entity_id} to set option to '{option}'."
                 )
+                # Optimistically reflect the new option immediately so the UI does
+                # not snap back while waiting for the next SSE push.
+                if self.coordinator.data is not None:
+                    self.coordinator.data[self._param_id] = new_api_value
+                self.async_write_ha_state()
                 await self.coordinator.async_request_refresh()
             else:
                 _LOGGER.error(

--- a/custom_components/innotemp/switch.py
+++ b/custom_components/innotemp/switch.py
@@ -207,22 +207,35 @@ class InnotempSwitch(InnotempCoordinatorEntity, SwitchEntity):
         # Let's use strict "0" and "1" as they are standard Innotemp boolean values.
         val_new = target_value_str
 
-        # Previous value handling
+        # Previous value handling.
+        #
+        # The controller uses ``val_prev`` for optimistic locking: a command is
+        # only applied when ``val_prev`` matches the parameter's *current* value.
+        # The current value must be read from the same var the entity displays
+        # (its own ``param_id``), exactly as ``is_on`` does. Previously this read
+        # the *mapped state var* from ``control_to_state_map`` which is a
+        # different (and often unpopulated) signal, so the first ``val_prev`` sent
+        # was a wrong guess and the device silently ignored the change.
         previous_api_value: Any | None = None
-        state_var = self.coordinator.control_to_state_map.get(self._param_id)
-        if state_var and self.coordinator.data:
-            previous_api_value = self.coordinator.data.get(state_var)
+        if self.coordinator.data:
+            previous_api_value = self.coordinator.data.get(self._param_id)
+            if previous_api_value is None:
+                # Fall back to the mapped state var if the control var is not
+                # present in the live data for some reason.
+                state_var = self.coordinator.control_to_state_map.get(self._param_id)
+                if state_var:
+                    previous_api_value = self.coordinator.data.get(state_var)
 
-        val_prev_options = []
+        val_prev_options: list[Any] = []
         if previous_api_value is not None:
-            val_prev_options.append(previous_api_value)
+            # Normalise to a clean "0"/"1" so the very first attempt carries the
+            # correct previous value (SSE may deliver "1.0", 1, etc.).
+            val_prev_options.append(
+                "1" if str(previous_api_value) in ("1", "1.0") else "0"
+            )
 
-        # Add the opposite value as a fallback option for prev value
-        # If we are turning ON, current state might be OFF ("0").
-        # If we are turning OFF, current state might be ON ("1").
-        # But we should also include both just in case.
-        possible_values = ["0", "1"]
-        for val in possible_values:
+        # Fallbacks: try both boolean states, then an empty val_prev.
+        for val in ("0", "1"):
             if val not in val_prev_options:
                 val_prev_options.append(val)
 
@@ -245,6 +258,13 @@ class InnotempSwitch(InnotempCoordinatorEntity, SwitchEntity):
                 _LOGGER.info(
                     f"Successfully sent command for {self.entity_id} to turn {'ON' if turn_on else 'OFF'}."
                 )
+                # Optimistically reflect the new state immediately. The SSE
+                # stream only republishes values periodically, and a plain
+                # refresh re-emits the (unchanged) cached data, which would make
+                # the toggle snap back to its old position.
+                if self.coordinator.data is not None:
+                    self.coordinator.data[self._param_id] = val_new
+                self.async_write_ha_state()
                 await self.coordinator.async_request_refresh()
             else:
                 _LOGGER.error(

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -1,0 +1,131 @@
+"""Regression tests for the writable control platforms (switch/select/number).
+
+These cover the command (write) path, which was broken in several ways:
+
+* ``val_prev`` was read from the wrong variable (the mapped state var instead of
+  the control's own value), so the controller's optimistic-locking check failed
+  and the change was silently dropped.
+* ``number`` sent the room's string ``var`` as ``room_id`` instead of the
+  numeric room id required by ``value.save.php``.
+* No optimistic state update meant the UI snapped back to the old value after a
+  successful command.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant import config_entries
+
+from custom_components.innotemp.coordinator import InnotempDataUpdateCoordinator
+from custom_components.innotemp.switch import InnotempSwitch
+from custom_components.innotemp.select import InnotempInputSelect
+from custom_components.innotemp.number import InnotempNumber
+
+ROOM = {"type": "room3", "var": "room3_param1", "label": "Room 3"}
+COMP = {"type": "param", "var": "room3_param1"}
+
+
+def _make_coordinator(data):
+    coordinator = MagicMock(spec=InnotempDataUpdateCoordinator)
+    coordinator.data = data
+    coordinator.control_to_state_map = {}
+    coordinator.api_client = MagicMock()
+    coordinator.api_client.async_send_command = AsyncMock(return_value=True)
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+def _config_entry():
+    return MagicMock(
+        spec=config_entries.ConfigEntry, unique_id="cfg", entry_id="test_entry_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_switch_uses_own_value_for_val_prev_and_updates_state(
+    hass: HomeAssistant,
+):
+    """Switch must send its own current value as the first ``val_prev``."""
+    param = "room3_param1_entry1"
+    coordinator = _make_coordinator({param: "1"})  # currently ON
+    switch = InnotempSwitch(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        3,
+        COMP,
+        param,
+        {"unit": "ONOFF", "var": param, "label": "Pump"},
+    )
+    switch.async_write_ha_state = MagicMock()
+
+    await switch.async_turn_off()
+
+    kwargs = coordinator.api_client.async_send_command.call_args.kwargs
+    assert kwargs["room_id"] == 3
+    assert kwargs["param"] == param
+    assert kwargs["val_new"] == "0"
+    # First previous value tried must match the actual current state ("1"),
+    # not a blind "0" guess.
+    assert kwargs["val_prev_options"][0] == "1"
+    # Optimistic update: state reflects the change immediately.
+    assert coordinator.data[param] == "0"
+    assert switch.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_select_uses_own_value_for_val_prev_and_updates_state(
+    hass: HomeAssistant,
+):
+    """Select must send its own current value as the first ``val_prev``."""
+    param = "room3_param1_e2"
+    coordinator = _make_coordinator({param: 1})  # currently On
+    select = InnotempInputSelect(
+        hass,
+        coordinator,
+        _config_entry(),
+        ROOM,
+        3,
+        COMP,
+        param,
+        {"unit": "ONOFFAUTO", "var": param, "label": "Mode"},
+    )
+    select.async_write_ha_state = MagicMock()
+
+    await select.async_select_option("Auto")
+
+    kwargs = coordinator.api_client.async_send_command.call_args.kwargs
+    assert kwargs["room_id"] == 3
+    assert kwargs["param"] == param
+    assert kwargs["val_new"] == 2  # Auto
+    assert kwargs["val_prev_options"][0] == 1  # current value first
+    assert coordinator.data[param] == 2
+    assert select.current_option == "Auto"
+
+
+@pytest.mark.asyncio
+async def test_number_sends_numeric_room_id_and_updates_state(hass: HomeAssistant):
+    """Number must send the numeric room id, not the room's string var."""
+    param = "room3_param1_n1"
+    coordinator = _make_coordinator({param: "18"})
+    number = InnotempNumber(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        param,
+        {"unit": "°C", "var": param, "label": "Setpoint"},
+    )
+    number.async_write_ha_state = MagicMock()
+
+    await number.async_set_native_value(21.0)
+
+    kwargs = coordinator.api_client.async_send_command.call_args.kwargs
+    # Regression: previously this was "room3_param1" (the string var).
+    assert kwargs["room_id"] == 3
+    assert kwargs["param"] == param
+    assert kwargs["val_new"] == 21.0
+    assert kwargs["val_prev_options"][0] == "18"
+    assert coordinator.data[param] == 21.0
+    assert number.native_value == 21.0


### PR DESCRIPTION
## Problem

Reading values worked, but **changing any control never took effect** — toggles, selects, and number inputs all failed to apply.

## Root causes (write/command path)

Three distinct bugs, each confirmed by capturing the exact `value.save.php` payload:

1. **`val_prev` read from the wrong variable (switch & select).** The entities display their value via `coordinator.data[param_id]` (the control's own var — this works), but the command read `val_prev` from `control_to_state_map[param_id]`, a *different* input/feedback var. That map relies on matching entry/input labels within a component, so it's frequently **empty**, leaving `val_prev` as a blind `"0"` guess. The controller uses `val_prev` for optimistic locking and **silently drops** a command whose `val_prev` doesn't match the current value. Fixed to read `val_prev` from the entity's own `param_id` (matching the API spec example `param=…gui001out1&val_prev=0`), falling back to the mapped state var only if needed.

2. **`number` sent the wrong `room_id`.** It passed `room_attributes["var"]` (e.g. `"room3_param1"`) where `value.save.php` requires the **numeric** room id (`3`), so every number write was rejected. Switch/select already used the numeric id; `number` now derives it via `extract_numeric_room_id`.

3. **No optimistic update → UI snapped back.** After a successful command, `async_request_refresh()` just re-emits the unchanged SSE cache, so a control reverted to its old value until the next push. Each platform now writes the new value into the coordinator data and calls `async_write_ha_state()`.

## Verification

A harness simulating each platform confirmed before → after:

| Platform | Before | After |
|---|---|---|
| Switch (ON→off) | first `val_prev` `'0'` (wrong) | `'1'` (correct); `is_on` flips to `False` |
| Select (On→Auto) | first `val_prev` `0` (wrong) | `1` (correct); `current_option` → `Auto` |
| Number (18→21) | `room_id='room3_param1'` | `room_id=3`; `native_value` → `21` |

## Tests

Adds `tests/test_controls.py` covering all three platforms' write paths (asserts correct `room_id`, `val_new`, first `val_prev`, and optimistic state). Changed files are `black`-clean.

> Note: `black --check` is already failing on `main` for four unrelated files (`__init__.py`, `api_parser.py`, `test_api.py`, `test_api_parser.py`); left out of scope to keep this diff focused.

https://claude.ai/code/session_01G1xmX2pd1CNAeAULcekX8g