### PR TITLE
Fix pre-existing CI: black formatting + stale test repairs

### DIFF
--- a/custom_components/innotemp/__init__.py
+++ b/custom_components/innotemp/__init__.py
@@ -12,7 +12,12 @@ from .coordinator import InnotempDataUpdateCoordinator
 from .const import DOMAIN
 from .api_parser import extract_initial_states, create_control_state_map
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SELECT, Platform.NUMBER, Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.SELECT,
+    Platform.NUMBER,
+    Platform.SWITCH,
+]
 
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.WARNING)  # Changed logger level to warning

--- a/custom_components/innotemp/api_parser.py
+++ b/custom_components/innotemp/api_parser.py
@@ -179,7 +179,9 @@ def create_control_state_map(config_data: Dict[str, Any]) -> Dict[str, str]:
                     continue  # We need both to make a pair
 
                 # Normalize entries and inputs to lists
-                entries = entries_raw if isinstance(entries_raw, list) else [entries_raw]
+                entries = (
+                    entries_raw if isinstance(entries_raw, list) else [entries_raw]
+                )
                 inputs = inputs_raw if isinstance(inputs_raw, list) else [inputs_raw]
 
                 # Create a lookup map for inputs based on their label
@@ -215,7 +217,9 @@ def create_control_state_map(config_data: Dict[str, Any]) -> Dict[str, str]:
                                 "Mapped control '%s' to state '%s' in component '%s' (Room: %s) using label: '%s'",
                                 control_var,
                                 state_var,
-                                component.get("@attributes", {}).get("type", container_key),
+                                component.get("@attributes", {}).get(
+                                    "type", container_key
+                                ),
                                 room_var,
                                 control_label,
                             )
@@ -513,6 +517,7 @@ def extract_initial_states(config_data_full: dict) -> dict:
 
     _LOGGER.info(f"Extracted {len(initial_states)} initial states for the coordinator.")
     return initial_states
+
 
 # def _example_sensor_item_processor(
 #     item_data: Dict[str, Any],

--- a/custom_components/innotemp/switch.py
+++ b/custom_components/innotemp/switch.py
@@ -189,7 +189,7 @@ class InnotempSwitch(InnotempCoordinatorEntity, SwitchEntity):
 
     async def _send_switch_command(self, turn_on: bool) -> None:
         """Helper to send the turn on/off command."""
-        target_value_str = "1" if turn_on else "0" # "1" for On, "0" for Off
+        target_value_str = "1" if turn_on else "0"  # "1" for On, "0" for Off
 
         # We need the API value (often the same as what we deduced)
         # Assuming ONOFF_OPTION_TO_API_VALUE maps "On" -> "1", "Off" -> "0"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,9 @@ def mock_client_session():
     session = MagicMock(spec=ClientSession)
     session.post = MagicMock()
     session.get = MagicMock()
+    # ``_api_request`` (used by send_command, get_config, ...) goes through
+    # ``session.request``; only ``async_login`` uses ``session.post`` directly.
+    session.request = MagicMock()
     return session
 
 
@@ -85,15 +88,15 @@ async def test_send_command_success(mock_client_session):
 
     async_context_manager = AsyncMock()
     async_context_manager.__aenter__.return_value = mock_response
-    mock_client_session.post.return_value = async_context_manager
-
+    # send_command issues the request via ``session.request``.
+    mock_client_session.request.return_value = async_context_manager
 
     success = await client.async_send_command(
         room_id=1, param="p1", val_new="10", val_prev_options=["5"]
     )
 
     assert success is True
-    mock_client_session.post.assert_called_once()
+    mock_client_session.request.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -122,24 +125,25 @@ async def test_retry_on_auth_error(mock_client_session):
     mock_command_success_response = MagicMock()
     mock_command_success_response.status = 200
     json_payload = {"info": "success_non_json"}
-    mock_command_success_response.json = AsyncMock(
-        return_value=json_payload
-    )
+    mock_command_success_response.json = AsyncMock(return_value=json_payload)
     mock_command_success_response.text = AsyncMock(
         return_value=json.dumps(json_payload)
     )
     cm_command_success = AsyncMock()
     cm_command_success.__aenter__.return_value = mock_command_success_response
 
-    mock_client_session.post.side_effect = [
+    # The command + retry go through ``session.request`` (redirect, then the
+    # successful retry); the re-login in between goes through ``session.post``.
+    mock_client_session.request.side_effect = [
         cm_redirect,
-        cm_login,
         cm_command_success,
     ]
+    mock_client_session.post.return_value = cm_login
 
     success = await client.async_send_command(
         room_id=1, param="p1", val_new="10", val_prev_options=["5"]
     )
 
     assert success is True
-    assert mock_client_session.post.call_count == 3
+    assert mock_client_session.request.call_count == 2
+    assert mock_client_session.post.call_count == 1

--- a/tests/test_api_parser.py
+++ b/tests/test_api_parser.py
@@ -39,7 +39,11 @@ def test_create_control_state_map():
                 "mixer": {
                     "@attributes": {"type": "mixer001", "label": "Main Mixer"},
                     "entry": [
-                        {"var": "control_mixer_1", "label": "Mischer 1", "unit": "VAR:"},
+                        {
+                            "var": "control_mixer_1",
+                            "label": "Mischer 1",
+                            "unit": "VAR:",
+                        },
                         {
                             "var": "control_mixer_2",
                             "label": "Unmatched Mischer",
@@ -123,7 +127,11 @@ def test_create_control_state_map():
             {
                 "@attributes": {"type": "room003", "var": "R3"},
                 "display": {
-                    "input": {"var": "some_display_var", "label": "Display", "unit": "W"}
+                    "input": {
+                        "var": "some_display_var",
+                        "label": "Display",
+                        "unit": "W",
+                    }
                 },
             },
         ]
@@ -224,14 +232,14 @@ def test_strip_html(input_text: Optional[str], expected_output: str):
         ("VAR::", None),  # Empty content
         ("VAR:InvalidFormat:", None),  # Part doesn't match pattern
         ("VAR:NoVal():", None),  # Part doesn't match pattern (empty value)
+        (
+            "VAR:NoName(val):",
             (
-                "VAR:NoName(val):",
-                (
-                    {"val": "NoName"},
-                    {"NoName": "val"},
-                    ["NoName"],
-                ),
-            ),  # This is actually valid, the test was wrong
+                {"val": "NoName"},
+                {"NoName": "val"},
+                ["NoName"],
+            ),
+        ),  # This is actually valid, the test was wrong
         ("VAR:NoBrackets:", None),  # Part doesn't match pattern
         ("VAR:One(1)Two(2):", None),  # Invalid part format (no colon separator)
         (
@@ -387,8 +395,7 @@ def mock_select_processor(
         ),
         # 4. JSON string for room list
         (
-            {
-                "roomlist_json": """
+            {"roomlist_json": """
                     [
                         {
                             "@attributes": {"type": "room002", "var": "ROOM_B_VAR", "label": "Room B"},
@@ -398,8 +405,7 @@ def mock_select_processor(
                             }
                         }
                     ]
-                """
-            },
+                """},
             ["display"],  # Container key for this test
             mock_item_processor,
             1,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,181 +1,125 @@
-"""Tests for the Innotemp sensor platform."""
+"""Tests for the Innotemp sensor platform.
 
-from unittest.mock import MagicMock, PropertyMock
+These exercise the current sensor entities directly (the previous version of
+this module asserted against an obsolete ``coordinator.data["sensors"]`` /
+``entity_description`` architecture that no longer exists).
+"""
+
+from unittest.mock import MagicMock
+
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant import config_entries
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-
-from custom_components.innotemp.sensor import async_setup_entry, InnotempSensor
-from custom_components.innotemp.const import DOMAIN
-
+from homeassistant.components.sensor import SensorDeviceClass
 
 from custom_components.innotemp.coordinator import InnotempDataUpdateCoordinator
+from custom_components.innotemp.sensor import (
+    InnotempSensor,
+    InnotempOnOffSensor,
+    InnotempEnumSensor,
+)
+
+ROOM = {"type": "room3", "var": "RM", "label": "Living Room"}
+COMP = {"type": "display", "var": "disp1"}
 
 
-@pytest.fixture
-def mock_coordinator_success(hass: HomeAssistant):
+def _coordinator(data):
     coordinator = MagicMock(spec=InnotempDataUpdateCoordinator)
-    coordinator.hass = hass
-    coordinator.data = {
-        "temp_sensor": "22.5",
-        "humidity_sensor": "45.0",
-        "power_sensor": "1.2",
-        "generic_sensor": "100",
-    }
-    config_entry_mock = MagicMock(
-        spec=config_entries.ConfigEntry, entry_id="test_entry_id"
-    )
-    type(coordinator).config_entry = PropertyMock(return_value=config_entry_mock)
-
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][config_entry_mock.entry_id] = {
-        "config": coordinator.data,  # Pass the coordinator's data as 'config' for sensor setup
-    }
+    coordinator.data = data
     return coordinator
 
 
-@pytest.fixture
-def mock_coordinator_failure(hass: HomeAssistant):
-    coordinator = MagicMock(spec=DataUpdateCoordinator)
-    coordinator.hass = hass
-    coordinator.data = {
-        "sensors": [
-            {"param": "temp_sensor_missing_data", "label": "Attic Temperature (°C)"},
-            {
-                "param": "sensor_no_label_data",
-                "label": "No Label Sensor",
-            },
-            {"param": "sensor_none_value", "label": "Sensor With None (°C)"},
-        ],
-        "sensor_none_value": None,  # Explicit None value
-    }
-    config_entry_mock = MagicMock(
-        spec=config_entries.ConfigEntry, entry_id="test_entry_id_failure"
+def _config_entry():
+    return MagicMock(
+        spec=config_entries.ConfigEntry, unique_id="cfg", entry_id="test_entry_id"
     )
-    type(coordinator).config_entry = PropertyMock(return_value=config_entry_mock)
-
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][config_entry_mock.entry_id] = {
-        "config": coordinator.data,
-    }
-    return coordinator
 
 
 @pytest.mark.asyncio
-async def test_sensor_setup_and_state_success(
-    hass: HomeAssistant,
-    mock_coordinator_success,
-):
-    """Test successful sensor setup, state, unit, and device class."""
-    add_entities_callback = MagicMock(spec=AddEntitiesCallback)
-    await async_setup_entry(
-        hass, mock_coordinator_success.config_entry, add_entities_callback
+async def test_regular_numeric_sensor(hass: HomeAssistant):
+    """A numeric sensor parses its value, unit and device class."""
+    coordinator = _coordinator({"temp1": "22.5"})
+    entity = InnotempSensor(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        {"var": "temp1", "unit": "°C", "label": "Temperature"},
     )
 
-    add_entities_callback.assert_called_once()
-    entities = add_entities_callback.call_args[0][0]
-    assert len(entities) == 4  # Based on mock_coordinator_success data
-    temp_sensor_config = mock_coordinator_success.data["sensors"][0]
-    temp_sensor_entity = next(  # Sensor 1: Temperature
-        e for e in entities if e.entity_description.key == temp_sensor_config["param"]
-    )
-    assert isinstance(temp_sensor_entity, InnotempSensor)
-    assert (
-        temp_sensor_entity.name == "Living Room Temperature (°C)"
-    )  # Full label as name
-    assert (
-        temp_sensor_entity.unique_id
-        == f"{mock_coordinator_success.config_entry.entry_id}-{temp_sensor_config['param']}"
-    )
-    assert temp_sensor_entity.state == 22.5
-    assert temp_sensor_entity.unit_of_measurement == "°C"
-    assert temp_sensor_entity.device_class == "temperature"
-    assert temp_sensor_entity.device_info is not None
-    assert temp_sensor_entity.device_info["identifiers"] == {
-        (DOMAIN, mock_coordinator_success.config_entry.entry_id)
-    }
-
-    humidity_sensor_config = mock_coordinator_success.data["sensors"][1]
-    humidity_sensor_entity = next(
-        e
-        for e in entities
-        if e.entity_description.key == humidity_sensor_config["param"]
-    )
-    assert humidity_sensor_entity.name == "Living Room Humidity (%)"
-    assert humidity_sensor_entity.state == 45.0
-    assert humidity_sensor_entity.unit_of_measurement == "%"
-    assert humidity_sensor_entity.device_class == "humidity"
-
-    power_sensor_config = mock_coordinator_success.data["sensors"][2]
-    power_sensor_entity = next(
-        e for e in entities if e.entity_description.key == power_sensor_config["param"]
-    )
-    assert power_sensor_entity.name == "Power Usage (kW)"
-    assert power_sensor_entity.state == 1.2
-    assert power_sensor_entity.unit_of_measurement == "kW"
-    assert power_sensor_entity.device_class == "power"
-
-    generic_sensor_config = mock_coordinator_success.data["sensors"][3]
-    generic_sensor_entity = next(
-        e
-        for e in entities
-        if e.entity_description.key == generic_sensor_config["param"]
-    )
-    assert generic_sensor_entity.name == "Generic Value"
-    assert generic_sensor_entity.state == 100
-    assert generic_sensor_entity.unit_of_measurement is None
-    assert generic_sensor_entity.device_class is None
+    assert entity.name == "RM - disp1 - Temperature"
+    assert entity.unique_id == "cfg_temp1"
+    assert entity.native_value == 22.5
+    assert entity.native_unit_of_measurement == "°C"
+    assert entity.device_class == SensorDeviceClass.TEMPERATURE
 
 
 @pytest.mark.asyncio
-async def test_sensor_state_failure(hass: HomeAssistant, mock_coordinator_failure):
-    """Test sensor states for unavailable or problematic data."""
-    add_entities_callback = MagicMock(spec=AddEntitiesCallback)
-
-    await async_setup_entry(
-        hass, mock_coordinator_failure.config_entry, add_entities_callback
+async def test_sensor_missing_value_is_none(hass: HomeAssistant):
+    """A sensor whose var is absent from coordinator data reports None."""
+    coordinator = _coordinator({"other": "1"})
+    entity = InnotempSensor(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        {"var": "temp1", "unit": "°C", "label": "Attic"},
     )
 
-    add_entities_callback.assert_called_once()
-    entities = add_entities_callback.call_args[0][0]
-    assert len(entities) == 3  # Based on mock_coordinator_failure data
+    assert entity.native_value is None
+    # Unit / device class are still derived from the config.
+    assert entity.native_unit_of_measurement == "°C"
+    assert entity.device_class == SensorDeviceClass.TEMPERATURE
 
-    missing_data_sensor_config = mock_coordinator_failure.data["sensors"][0]
-    missing_data_sensor_entity = next(  # Sensor 1: Data key missing in coordinator.data
-        e
-        for e in entities
-        if e.entity_description.key == missing_data_sensor_config["param"]
-    )
-    assert missing_data_sensor_entity.state is None  # Should be None as key is missing
-    assert (
-        missing_data_sensor_entity.unit_of_measurement == "°C"
-    )  # Unit should still be parsed
-    assert missing_data_sensor_entity.device_class == "temperature"
 
-    # Sensor 2: Data might be missing or param not in coordinator.data (similar to above)
-    # This depends on how InnotempSensor handles get(param, None)
-    assert missing_data_sensor_entity.name == "Attic Temperature (°C)"
-    no_label_data_sensor_config = mock_coordinator_failure.data["sensors"][1]
-    no_label_data_sensor_entity = next(
-        e
-        for e in entities
-        if e.entity_description.key == no_label_data_sensor_config["param"]
+@pytest.mark.asyncio
+async def test_generic_sensor_returns_raw_string(hass: HomeAssistant):
+    """A sensor with a non-numeric unit returns the raw value as a string."""
+    coordinator = _coordinator({"gen1": "100"})
+    entity = InnotempSensor(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        {"var": "gen1", "unit": "x", "label": "Generic"},
     )
-    assert no_label_data_sensor_entity.name == "No Label Sensor"
-    assert (
-        no_label_data_sensor_entity.state is None
-    )  # Assuming 'sensor_no_label_data' key is missing
-    assert no_label_data_sensor_entity.unit_of_measurement is None  # No unit in label
-    assert no_label_data_sensor_entity.device_class is None
 
-    none_value_sensor_config = mock_coordinator_failure.data["sensors"][2]
-    none_value_sensor_entity = next(
-        e
-        for e in entities
-        if e.entity_description.key == none_value_sensor_config["param"]
+    assert entity.native_value == "100"
+    assert entity.device_class is None
+
+
+@pytest.mark.asyncio
+async def test_onoff_sensor_maps_to_text(hass: HomeAssistant):
+    """An ONOFF sensor maps the raw API value to On/Off."""
+    coordinator = _coordinator({"oo1": "1"})
+    entity = InnotempOnOffSensor(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        {"var": "oo1", "unit": "ONOFF", "label": "Pump"},
     )
-    assert none_value_sensor_entity.state is None  # Value is None
-    assert none_value_sensor_entity.unit_of_measurement == "°C"
-    assert none_value_sensor_entity.device_class == "temperature"
+
+    assert entity.name == "RM - disp1 - Pump"
+    assert entity.unique_id == "cfg_oo1_onoff_status"
+    assert entity.native_value == "On"
+    assert entity.options == ["Off", "On"]
+    assert entity.device_class == SensorDeviceClass.ENUM
+
+
+@pytest.mark.asyncio
+async def test_enum_sensor_maps_to_text(hass: HomeAssistant):
+    """An ONOFFAUTO sensor maps the raw API value to Off/On/Auto."""
+    coordinator = _coordinator({"en1": 2})
+    entity = InnotempEnumSensor(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        {"var": "en1", "unit": "ONOFFAUTO", "label": "Mode"},
+    )
+
+    assert entity.unique_id == "cfg_en1_status"
+    assert entity.native_value == "Auto"
+    assert entity.options == ["Off", "On", "Auto"]
+    assert entity.device_class == SensorDeviceClass.ENUM


### PR DESCRIPTION
## Why

The CI `build` job runs `black --check .` over the whole repo **before** pytest. On `main`, several files are black-noncompliant *and* four tests are broken — so the job never reaches green, and the black failure masks the test failures. This PR fixes both so `main`'s CI is green. (Split out from #46 to keep that PR focused on the control-write bug.)

## Changes

**Black formatting (no logic changes)** — verified with `git diff -w`:
- `custom_components/innotemp/__init__.py`, `api_parser.py`, `switch.py`
- `tests/test_api.py`, `tests/test_api_parser.py`

**`test_api` — stale mocks**: the tests mocked `session.post`, but `api._api_request` (used by `async_send_command`, `get_config`, …) issues requests via `session.request`; only `async_login` uses `session.post`. The mocks now target the real call path:
- `test_send_command_success`: assert on `session.request`.
- `test_retry_on_auth_error`: redirect + successful retry on `session.request`, the re-login on `session.post`.

Verified against the real `api.py` (returns `True`; `request` called 2×, `post` 1× in the retry case).

**`test_sensor` — obsolete architecture**: the previous tests asserted against a `coordinator.data["sensors"]` list and `entity_description.key`, neither of which exists in the current `sensor.py`. Rewritten to instantiate the current sensor entities directly and assert `native_value` / unit / `device_class` / `options` for the regular, generic, `ONOFF`, and `ONOFFAUTO` sensor types. Expected values were confirmed against the real `sensor.py`.

## Verification

`black --check .` is clean locally. The HA-dependent tests can't run in my sandbox (HA test deps fail to build), so the test logic was verified by exercising the real `api.py`/`sensor.py` with equivalent mocks; CI on this PR is the authoritative check.

## Relationship to #46

#46 (the control-write bug fix) stays red until this merges. Once this is in `main`, I'll rebase #46 and it should go green.

https://claude.ai/code/session_01G1xmX2pd1CNAeAULcekX8g

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1xmX2pd1CNAeAULcekX8g)_