### PR TITLE
Fix session cookie handling, add unload support, harden value paths + tests

### DIFF
--- a/custom_components/innotemp/__init__.py
+++ b/custom_components/innotemp/__init__.py
@@ -2,10 +2,12 @@
 
 import logging
 
+import aiohttp
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .api import InnotempApiClient
 from .coordinator import InnotempDataUpdateCoordinator
@@ -65,7 +67,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data["username"]
     password = entry.data["password"]
 
-    session = async_get_clientsession(hass)
+    # The Innotemp controller authenticates via a PHPSESSID cookie and is
+    # typically addressed by a bare IP. aiohttp's default CookieJar silently
+    # *discards* cookies set by IP hosts (unsafe=False), so the shared HA
+    # session never kept the session cookie: login appeared to succeed but
+    # every subsequent request (especially the SSE stream, which carries no
+    # credentials in its body) was unauthenticated. Use a dedicated session
+    # with an unsafe cookie jar so the session cookie survives.
+    session = async_create_clientsession(
+        hass, cookie_jar=aiohttp.CookieJar(unsafe=True)
+    )
     _LOGGER.debug(
         f"Innotemp: Initializing API client. Session type: {type(session)}, Host: {host}"
     )
@@ -125,6 +136,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "api": api_client,
         "coordinator": coordinator,
         "config": config_data,  # Still store original config_data for entity discovery if needed
+        "session": session,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -135,3 +147,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator.async_config_entry_first_refresh()
 
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry, stopping the SSE listener and closing the session.
+
+    Without this, removing/reloading the integration left the SSE background
+    task running forever and re-adding the entry spawned a second listener.
+    """
+    _LOGGER.info("[innotemp] Unloading entry %s", entry.entry_id)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        data = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        if data:
+            api_client: InnotempApiClient = data["api"]
+            coordinator: InnotempDataUpdateCoordinator = data["coordinator"]
+
+            await api_client.async_sse_disconnect()
+
+            sse_wrapper = getattr(coordinator, "sse_task", None)
+            if sse_wrapper and not sse_wrapper.done():
+                sse_wrapper.cancel()
+
+            await coordinator.async_shutdown()
+
+            session = data.get("session")
+            if session:
+                await session.close()
+        _LOGGER.info("[innotemp] Entry %s unloaded", entry.entry_id)
+
+    return unload_ok

--- a/custom_components/innotemp/api.py
+++ b/custom_components/innotemp/api.py
@@ -43,7 +43,9 @@ class InnotempApiClient:
             username,
         )
 
-    def _sanitize_data_for_log(self, data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    def _sanitize_data_for_log(
+        self, data: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
         """Return a copy of data with password masked for logging."""
         if data is None:
             return None
@@ -51,6 +53,43 @@ class InnotempApiClient:
         if "pw" in sanitized:
             sanitized["pw"] = "***"
         return sanitized
+
+    def _log_session_cookie_state(self, response) -> None:
+        """Log whether the login session cookie was actually stored.
+
+        The controller authenticates follow-up requests (notably the SSE
+        stream) via a PHPSESSID cookie. aiohttp's default CookieJar drops
+        cookies set by bare-IP hosts, which makes login look successful while
+        every later request is unauthenticated — log that condition loudly.
+        """
+        try:
+            set_cookie = response.headers.getall("Set-Cookie", [])
+        except AttributeError:  # plain dict (tests/mocks)
+            value = response.headers.get("Set-Cookie")
+            set_cookie = [value] if value else []
+
+        jar = getattr(self._session, "cookie_jar", None)
+        stored_names: list[str] = []
+        if jar is not None:
+            try:
+                stored_names = [cookie.key for cookie in jar]
+            except TypeError:
+                stored_names = []
+
+        _LOGGER.debug(
+            "[innotemp] Login cookies: Set-Cookie headers=%s, jar now holds=%s",
+            set_cookie,
+            stored_names,
+        )
+        if set_cookie and not stored_names:
+            _LOGGER.warning(
+                "[innotemp] Server sent a session cookie on login but the "
+                "cookie jar did not store it (host=%s). Requests after login "
+                "will likely be rejected. This happens with aiohttp's default "
+                "cookie jar and IP-address hosts; the integration must use a "
+                "CookieJar(unsafe=True) session.",
+                self._host,
+            )
 
     async def _api_request(
         self,
@@ -65,7 +104,11 @@ class InnotempApiClient:
         log_data = self._sanitize_data_for_log(data)
         _LOGGER.debug(
             "[innotemp] >>> %s %s | data=%s | attempt=%d | logged_in=%s",
-            method, url, log_data, attempt, self._is_logged_in,
+            method,
+            url,
+            log_data,
+            attempt,
+            self._is_logged_in,
         )
         try:
             async with self._session.request(
@@ -76,19 +119,26 @@ class InnotempApiClient:
                 _LOGGER.debug(
                     "[innotemp] <<< %s %s | status=%s | content_type=%s | "
                     "elapsed=%.0fms | headers=%s",
-                    method, url, response.status,
-                    response.content_type, elapsed, dict(response.headers),
+                    method,
+                    url,
+                    response.status,
+                    response.content_type,
+                    elapsed,
+                    dict(response.headers),
                 )
                 _LOGGER.debug(
                     "[innotemp] <<< %s %s | body=%s",
-                    method, url, response_text,
+                    method,
+                    url,
+                    response_text,
                 )
 
                 if response.status in [301, 302]:
                     location = response.headers.get("Location", "unknown")
                     _LOGGER.warning(
                         "[innotemp] Redirect %s -> %s (session likely expired)",
-                        url, location,
+                        url,
+                        location,
                     )
                     raise InnotempAuthError(
                         f"Request to {url} was redirected to {location}, session likely expired."
@@ -109,7 +159,8 @@ class InnotempApiClient:
                     ):
                         _LOGGER.warning(
                             "[innotemp] Access denied for %s: %s",
-                            endpoint, json_response,
+                            endpoint,
+                            json_response,
                         )
                         raise InnotempAuthError(
                             f"Access denied by API payload for {endpoint}: {json_response}"
@@ -118,7 +169,8 @@ class InnotempApiClient:
                 except json.JSONDecodeError:
                     _LOGGER.warning(
                         "[innotemp] Non-JSON response from %s: %s",
-                        endpoint, response_text[:500],
+                        endpoint,
+                        response_text[:500],
                     )
                     return {"info": "success_non_json"}
 
@@ -126,7 +178,11 @@ class InnotempApiClient:
             elapsed = (time.monotonic() - t_start) * 1000
             _LOGGER.error(
                 "[innotemp] HTTP error for %s %s: status=%s, message=%s, elapsed=%.0fms",
-                method, url, e.status, e.message, elapsed,
+                method,
+                url,
+                e.status,
+                e.message,
+                elapsed,
             )
             if e.status in [401, 403]:
                 raise InnotempAuthError(
@@ -138,7 +194,11 @@ class InnotempApiClient:
             elapsed = (time.monotonic() - t_start) * 1000
             _LOGGER.error(
                 "[innotemp] Connection error for %s %s: %s (type=%s, elapsed=%.0fms)",
-                method, url, e, type(e).__name__, elapsed,
+                method,
+                url,
+                e,
+                type(e).__name__,
+                elapsed,
             )
             raise InnotempApiError(f"Connection error for {endpoint}: {e}") from e
 
@@ -150,14 +210,17 @@ class InnotempApiClient:
             if not self._is_logged_in:
                 _LOGGER.debug(
                     "[innotemp] Not logged in before %s %s, logging in first",
-                    method, endpoint,
+                    method,
+                    endpoint,
                 )
                 await self.async_login()
             return await self._api_request(method, endpoint, data)
         except InnotempAuthError as e:
             _LOGGER.info(
                 "[innotemp] Auth error for %s %s (%s), re-login and retry",
-                method, endpoint, e,
+                method,
+                endpoint,
+                e,
             )
             await self.async_login()
             return await self._api_request(method, endpoint, data)
@@ -169,13 +232,17 @@ class InnotempApiClient:
         url = f"{self._base_url}/groups.read.php"
 
         _LOGGER.info(
-            "[innotemp] Login attempt: url=%s, username=%s", url, self._username,
+            "[innotemp] Login attempt: url=%s, username=%s",
+            url,
+            self._username,
         )
         t_start = time.monotonic()
 
         try:
             async with self._session.post(
-                url, data=login_data, allow_redirects=False,
+                url,
+                data=login_data,
+                allow_redirects=False,
             ) as response:
                 elapsed = (time.monotonic() - t_start) * 1000
                 response_text = await response.text()
@@ -183,11 +250,14 @@ class InnotempApiClient:
                 _LOGGER.debug(
                     "[innotemp] Login response: status=%s, content_type=%s, "
                     "elapsed=%.0fms, headers=%s",
-                    response.status, response.content_type,
-                    elapsed, dict(response.headers),
+                    response.status,
+                    response.content_type,
+                    elapsed,
+                    dict(response.headers),
                 )
                 _LOGGER.debug(
-                    "[innotemp] Login response body: %s", response_text[:2000],
+                    "[innotemp] Login response body: %s",
+                    response_text[:2000],
                 )
 
                 if response.status in [301, 302]:
@@ -195,7 +265,8 @@ class InnotempApiClient:
                     _LOGGER.error(
                         "[innotemp] Login redirected: %s -> %s "
                         "(device may require HTTPS or different path)",
-                        url, location,
+                        url,
+                        location,
                     )
                     raise InnotempAuthError(
                         f"Login redirected to {location} — check host address"
@@ -204,7 +275,8 @@ class InnotempApiClient:
                 if response.status != 200:
                     _LOGGER.error(
                         "[innotemp] Login HTTP error: status=%s, body=%s",
-                        response.status, response_text[:500],
+                        response.status,
+                        response_text[:500],
                     )
                     response.raise_for_status()
 
@@ -220,22 +292,30 @@ class InnotempApiClient:
                     _LOGGER.error(
                         "[innotemp] Login response is not valid JSON: "
                         "error=%s, body=%s",
-                        je, response_text[:500],
+                        je,
+                        response_text[:500],
                     )
                     raise InnotempAuthError(
                         f"Login failed: response is not JSON: {response_text[:200]}"
                     ) from je
 
                 _LOGGER.debug(
-                    "[innotemp] Login parsed response: %s", json_response,
+                    "[innotemp] Login parsed response: %s",
+                    json_response,
                 )
 
-                info = json_response.get("info") if isinstance(json_response, dict) else None
+                info = (
+                    json_response.get("info")
+                    if isinstance(json_response, dict)
+                    else None
+                )
 
                 if info == "success":
                     _LOGGER.info(
-                        "[innotemp] Login successful (%.0fms)", elapsed,
+                        "[innotemp] Login successful (%.0fms)",
+                        elapsed,
                     )
+                    self._log_session_cookie_state(response)
                     self._is_logged_in = True
                     return
 
@@ -253,7 +333,9 @@ class InnotempApiClient:
             elapsed = (time.monotonic() - t_start) * 1000
             _LOGGER.error(
                 "[innotemp] Login connection error: %s (type=%s, elapsed=%.0fms)",
-                e, type(e).__name__, elapsed,
+                e,
+                type(e).__name__,
+                elapsed,
             )
             raise InnotempAuthError(
                 f"Login connection failed: {type(e).__name__}: {e}"
@@ -262,7 +344,9 @@ class InnotempApiClient:
             elapsed = (time.monotonic() - t_start) * 1000
             _LOGGER.error(
                 "[innotemp] Login unexpected error: %s (type=%s, elapsed=%.0fms)",
-                e, type(e).__name__, elapsed,
+                e,
+                type(e).__name__,
+                elapsed,
             )
             raise InnotempAuthError(
                 f"Login failed unexpectedly: {type(e).__name__}: {e}"
@@ -292,7 +376,10 @@ class InnotempApiClient:
         _LOGGER.info(
             "[innotemp] Sending command: room_id=%s, param=%s, val_new=%s, "
             "val_prev_options=%s",
-            room_id, param, val_new, val_prev_options,
+            room_id,
+            param,
+            val_new,
+            val_prev_options,
         )
         for i, val_prev in enumerate(val_prev_options):
             command_data = {
@@ -310,40 +397,57 @@ class InnotempApiClient:
             _LOGGER.debug(
                 "[innotemp] Command attempt %d/%d: room=%s, param=%s, "
                 "new=%s, prev=%s",
-                i + 1, len(val_prev_options), room_id, param, val_new, val_prev,
+                i + 1,
+                len(val_prev_options),
+                room_id,
+                param,
+                val_new,
+                val_prev,
             )
 
             try:
                 result = await self._execute_with_retry(
                     "POST", "value.save.php", data=command_data
                 )
-                if result and result.get("info", "").startswith("success"):
+                if result and str(result.get("info") or "").startswith("success"):
                     _LOGGER.info(
                         "[innotemp] Command success: room=%s, param=%s, "
                         "new=%s, prev=%s, response=%s",
-                        room_id, param, val_new, val_prev, result,
+                        room_id,
+                        param,
+                        val_new,
+                        val_prev,
+                        result,
                     )
                     return True
                 else:
                     _LOGGER.warning(
                         "[innotemp] Command rejected: room=%s, param=%s, "
                         "prev=%s, response=%s",
-                        room_id, param, val_prev, result,
+                        room_id,
+                        param,
+                        val_prev,
+                        result,
                     )
             except InnotempAuthError as e:
                 _LOGGER.error(
-                    "[innotemp] Command auth error (aborting): %s", e,
+                    "[innotemp] Command auth error (aborting): %s",
+                    e,
                 )
                 raise
             except InnotempApiError as e:
                 _LOGGER.error(
-                    "[innotemp] Command API error (trying next prev): %s", e,
+                    "[innotemp] Command API error (trying next prev): %s",
+                    e,
                 )
 
         _LOGGER.error(
             "[innotemp] Command failed all attempts: room=%s, param=%s, "
             "val_new=%s, tried prev_values=%s",
-            room_id, param, val_new, val_prev_options,
+            room_id,
+            param,
+            val_new,
+            val_prev_options,
         )
         return False
 
@@ -368,14 +472,16 @@ class InnotempApiClient:
 
             _LOGGER.info(
                 "[innotemp] Fetched %d signal names: %s",
-                len(response), response,
+                len(response),
+                response,
             )
             self._signal_names_cache = response
             return response
 
         _LOGGER.error(
             "[innotemp] Signal names response not a list: type=%s, value=%s",
-            type(response).__name__, response,
+            type(response).__name__,
+            response,
         )
         self._signal_names_cache = None
         raise InnotempApiError(
@@ -397,7 +503,8 @@ class InnotempApiClient:
                 reconnect_count += 1
                 msg_count = 0
                 _LOGGER.info(
-                    "[innotemp] SSE listener starting (attempt #%d)", reconnect_count,
+                    "[innotemp] SSE listener starting (attempt #%d)",
+                    reconnect_count,
                 )
                 try:
                     if not self._is_logged_in:
@@ -413,14 +520,33 @@ class InnotempApiClient:
                     sse_url = f"{self._base_url}/live_signal.read.SSE.php"
                     _LOGGER.info(
                         "[innotemp] SSE connecting: url=%s, signals=%d",
-                        sse_url, len(signal_names),
+                        sse_url,
+                        len(signal_names),
                     )
 
-                    async with self._session.get(sse_url) as response:
+                    # allow_redirects=False: an expired session makes the
+                    # server redirect to the login page. Following it would
+                    # yield an HTTP-200 HTML page with no SSE data, and the
+                    # listener would silently reconnect forever without ever
+                    # re-authenticating.
+                    async with self._session.get(
+                        sse_url, allow_redirects=False
+                    ) as response:
                         _LOGGER.debug(
                             "[innotemp] SSE connected: status=%s, headers=%s",
-                            response.status, dict(response.headers),
+                            response.status,
+                            dict(response.headers),
                         )
+                        if response.status in [301, 302]:
+                            location = response.headers.get("Location", "unknown")
+                            _LOGGER.warning(
+                                "[innotemp] SSE request redirected to %s "
+                                "(session expired), re-authenticating",
+                                location,
+                            )
+                            raise InnotempAuthError(
+                                f"SSE request redirected to {location}"
+                            )
                         response.raise_for_status()
                         async for line in response.content:
                             if not line.startswith(b"data:"):
@@ -431,21 +557,30 @@ class InnotempApiClient:
                                 data_list = json.loads(data_str)
                                 if isinstance(data_list, list):
                                     _LOGGER.debug(
-                                        "[innotemp] SSE msg #%d: %s", msg_count, data_list,
+                                        "[innotemp] SSE msg #%d: %s",
+                                        msg_count,
+                                        data_list,
                                     )
 
                                     if len(data_list) != len(signal_names):
                                         _LOGGER.error(
                                             "[innotemp] SSE length mismatch: "
-                                            "expected %d signals, got %d values",
-                                            len(signal_names), len(data_list),
+                                            "expected %d signals, got %d values; "
+                                            "reconnecting with fresh signal names",
+                                            len(signal_names),
+                                            len(data_list),
                                         )
                                         self._signal_names_cache = None
-                                        continue
+                                        # The local signal_names list is stale;
+                                        # break out so the outer loop refetches
+                                        # it instead of erroring on every
+                                        # message until the stream drops.
+                                        break
 
                                     processed_data = dict(zip(signal_names, data_list))
                                     _LOGGER.debug(
-                                        "[innotemp] SSE processed: %s", processed_data,
+                                        "[innotemp] SSE processed: %s",
+                                        processed_data,
                                     )
 
                                     if callback is None:
@@ -459,25 +594,35 @@ class InnotempApiClient:
                                         callback(processed_data)
                                 else:
                                     _LOGGER.warning(
-                                        "[innotemp] SSE non-list data: %s", data_list,
+                                        "[innotemp] SSE non-list data: %s",
+                                        data_list,
                                     )
                             except (json.JSONDecodeError, IndexError) as e:
                                 _LOGGER.warning(
                                     "[innotemp] SSE parse error: %s, line=%s",
-                                    e, line[:200],
+                                    e,
+                                    line[:200],
                                 )
 
+                except InnotempAuthError as e:
+                    _LOGGER.error(
+                        "[innotemp] SSE auth error, re-login and retry in 30s: %s",
+                        e,
+                    )
+                    self._is_logged_in = False
                 except InnotempApiError as e:
                     _LOGGER.error("[innotemp] SSE API error, retry in 30s: %s", e)
                 except aiohttp.ClientError as e:
                     _LOGGER.error(
                         "[innotemp] SSE connection error (type=%s), retry in 30s: %s",
-                        type(e).__name__, e,
+                        type(e).__name__,
+                        e,
                     )
                     self._is_logged_in = False
                 except Exception as e:
                     _LOGGER.exception(
-                        "[innotemp] SSE unexpected error, retry in 30s: %s", e,
+                        "[innotemp] SSE unexpected error, retry in 30s: %s",
+                        e,
                     )
                     self._is_logged_in = False
 
@@ -485,6 +630,11 @@ class InnotempApiClient:
                     "[innotemp] SSE disconnected after %d messages, reconnecting in 30s",
                     msg_count,
                 )
+                # Per the API spec, a lost SSE stream should be followed by a
+                # full re-authentication before reconnecting. A stream that
+                # ended cleanly with zero messages is also a strong hint the
+                # session was not valid in the first place.
+                self._is_logged_in = False
                 await asyncio.sleep(30)
 
         self._sse_task = asyncio.create_task(sse_listener())

--- a/custom_components/innotemp/api_parser.py
+++ b/custom_components/innotemp/api_parser.py
@@ -36,6 +36,25 @@ ONOFF_OPTION_TO_API_VALUE: Dict[str, str] = (
 ONOFF_OPTIONS_LIST: List[str] = ["Off", "On"]
 
 
+def coerce_api_int(value: Any) -> Optional[int]:
+    """Coerce an API value to an int, or return None if not possible.
+
+    Values arrive from the SSE stream and the config in mixed forms:
+    ``1``, ``"1"``, ``1.0``, ``"1.0"``, ``"2"`` ... A plain ``int(value)``
+    raises on ``"1.0"``, which made enum lookups fail for float-formatted
+    values. Only integral values are accepted (``"1.5"`` returns None).
+    """
+    if value is None:
+        return None
+    try:
+        as_float = float(str(value).strip())
+    except (ValueError, TypeError):
+        return None
+    if not as_float.is_integer():
+        return None
+    return int(as_float)
+
+
 def strip_html(text: str | None) -> str:
     """Remove HTML tags from a string."""
     if text is None:

--- a/custom_components/innotemp/config_flow.py
+++ b/custom_components/innotemp/config_flow.py
@@ -1,17 +1,15 @@
 """Config flow for Innotemp Heating Controller."""
 
-import asyncio
 import logging
+
+import aiohttp
 import voluptuous as vol
 
-from homeassistant import config_entries, core
-from homeassistant.const import Platform
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant import config_entries
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import DOMAIN
 from .api import InnotempApiClient
-from .coordinator import InnotempDataUpdateCoordinator
-from . import PLATFORMS  # Import PLATFORMS from __init__.py
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,9 +53,15 @@ class InnotempConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             username = user_input["username"]
             _LOGGER.info(
                 "[innotemp] Config flow: attempting login to host=%s, username=%s",
-                host, username,
+                host,
+                username,
             )
-            session = async_get_clientsession(self.hass)
+            # Use an unsafe cookie jar so the controller's PHPSESSID cookie is
+            # kept even when the host is a bare IP address (aiohttp's default
+            # jar drops cookies from IP hosts). Matches async_setup_entry.
+            session = async_create_clientsession(
+                self.hass, cookie_jar=aiohttp.CookieJar(unsafe=True)
+            )
             api_client = InnotempApiClient(
                 session,
                 host,
@@ -73,7 +77,8 @@ class InnotempConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except Exception as ex:
                 _LOGGER.error(
                     "[innotemp] Config flow: login failed: %s (type=%s)",
-                    ex, type(ex).__name__,
+                    ex,
+                    type(ex).__name__,
                 )
                 errors["base"] = "cannot_connect"
                 return self.async_show_form(
@@ -81,74 +86,9 @@ class InnotempConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data_schema=data_schema,
                     errors=errors,
                 )
+            finally:
+                await session.close()
 
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
         )
-
-
-async def async_setup_entry(
-    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
-) -> bool:
-    """Set up Innotemp Heating Controller from a config entry."""
-
-    hass.data.setdefault(DOMAIN, {})
-
-    host = entry.data["host"]
-    username = entry.data["username"]
-    password = entry.data["password"]
-
-    session = async_get_clientsession(hass)
-    api_client = InnotempApiClient(session, host, username, password)
-
-    # Login and fetch initial configuration
-    try:
-        await api_client.async_login()
-        config_data = await api_client.async_get_config()
-        _LOGGER.debug("Initial configuration fetched: %s", config_data)
-    except Exception as ex:
-        _LOGGER.error("Failed to connect and fetch initial config: %s", ex)
-        return False
-
-    # Correct instantiation of the coordinator, similar to __init__.py
-    # Use the module-level _LOGGER for consistency
-    coordinator = InnotempDataUpdateCoordinator(hass, _LOGGER, api_client)
-
-    # Pass the coordinator's async_set_updated_data as the callback for SSE
-    # It's possible this whole async_setup_entry in config_flow.py is problematic
-    # if it races with or duplicates the one in __init__.py.
-    _LOGGER.debug(
-        "Config_flow.py: Setting up SSE connection via its async_setup_entry."
-    )
-
-    hass.data[DOMAIN][entry.entry_id] = {
-        "api": api_client,
-        "coordinator": coordinator,
-        "config": config_data,  # Store config data for entity creation
-    }
-
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    return True
-
-
-async def async_unload_entry(
-    hass: core.HomeAssistant, entry: config_entries.ConfigEntry
-) -> bool:
-    """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        api_client = hass.data[DOMAIN][entry.entry_id]["api"]
-        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-
-        # Disconnect SSE before removing the entry data
-        if coordinator.sse_task:
-            await api_client.async_sse_disconnect()
-            coordinator.sse_task.cancel()
-            try:
-                await coordinator.sse_task
-            except asyncio.CancelledError:
-                pass
-
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok

--- a/custom_components/innotemp/number.py
+++ b/custom_components/innotemp/number.py
@@ -261,11 +261,26 @@ class InnotempNumber(InnotempCoordinatorEntity, NumberEntity):
         if self.coordinator.data is not None:
             previous_api_value = self.coordinator.data.get(self._param_id)
 
-        api_value_to_send = value
+        # The controller expects plain numbers; the web UI sends integers
+        # without a decimal point (val_new=21, not 21.0). Sending "21.0" for
+        # integral values risks rejection, so normalise those to ints.
+        api_value_to_send = int(value) if float(value).is_integer() else value
 
-        # Build the list of previous values to try.
-        # First, the last known value, then None as a fallback (will be sent as an empty string).
-        val_prev_options = [previous_api_value, None]
+        # Build the list of previous values to try: the last known value first
+        # (raw, plus an int-normalised form in case the device compares the
+        # exact string), then None as a fallback (sent as an empty string).
+        val_prev_options: list[Any] = []
+        if previous_api_value is not None:
+            val_prev_options.append(previous_api_value)
+            try:
+                prev_float = float(previous_api_value)
+                if prev_float.is_integer():
+                    normalized_prev = str(int(prev_float))
+                    if normalized_prev not in [str(v) for v in val_prev_options]:
+                        val_prev_options.append(normalized_prev)
+            except (ValueError, TypeError):
+                pass
+        val_prev_options.append(None)
 
         _LOGGER.debug(
             f"Sending command for {self.entity_id}: room {self._api_room_id}, param {self._param_id}, "

--- a/custom_components/innotemp/select.py
+++ b/custom_components/innotemp/select.py
@@ -8,18 +8,13 @@ from typing import Any, Dict, Optional
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity_registry import async_get, EntityRegistry
-from homeassistant.helpers.entity_registry import (
-    EntityRegistry,
-    async_get,
-    RegistryEntry,
-)
 
 from .const import DOMAIN
 from .coordinator import InnotempDataUpdateCoordinator, InnotempCoordinatorEntity
 from .api_parser import (
+    coerce_api_int,
     strip_html,
     process_room_config_data,
     API_VALUE_TO_ONOFFAUTO_OPTION,
@@ -191,20 +186,21 @@ class InnotempInputSelect(InnotempCoordinatorEntity, SelectEntity):
         if api_value is None:
             return None  # Or a default option
 
-        # Convert numeric API value to string option
-        try:
-            # Ensure api_value is treated as an integer for dictionary lookup
-            selected_option = API_VALUE_TO_ONOFFAUTO_OPTION.get(int(api_value))
-            if selected_option is None:
-                _LOGGER.warning(
-                    f"InnotempInputSelect.current_option: Unknown API value '{api_value}' for param_id {self._param_id} on entity {self.entity_id}. Not in {API_VALUE_TO_ONOFFAUTO_OPTION}"
-                )
-            return selected_option
-        except (ValueError, TypeError):
+        # Convert the API value to an int for the lookup. Values may arrive as
+        # "1", 1, or "1.0" (int("1.0") raises, which made the option unknown).
+        int_value = coerce_api_int(api_value)
+        if int_value is None:
             _LOGGER.warning(
                 f"InnotempInputSelect.current_option: Could not convert API value '{api_value}' to int for param_id {self._param_id} on entity {self.entity_id}."
             )
             return None
+
+        selected_option = API_VALUE_TO_ONOFFAUTO_OPTION.get(int_value)
+        if selected_option is None:
+            _LOGGER.warning(
+                f"InnotempInputSelect.current_option: Unknown API value '{api_value}' for param_id {self._param_id} on entity {self.entity_id}. Not in {API_VALUE_TO_ONOFFAUTO_OPTION}"
+            )
+        return selected_option
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
@@ -231,13 +227,14 @@ class InnotempInputSelect(InnotempCoordinatorEntity, SelectEntity):
                     previous_api_value = self.coordinator.data.get(state_var)
 
         # Build the list of previous values to try, normalising the current value
-        # to its integer API form so the first attempt carries the correct prev.
+        # to its integer API form so the first attempt carries the correct prev
+        # (SSE may deliver "1.0", which int() alone cannot parse).
         val_prev_options = []
         if previous_api_value is not None:
-            try:
-                val_prev_options.append(int(previous_api_value))
-            except (ValueError, TypeError):
-                val_prev_options.append(previous_api_value)
+            prev_int = coerce_api_int(previous_api_value)
+            val_prev_options.append(
+                prev_int if prev_int is not None else previous_api_value
+            )
 
         # Add all possible enum values, ensuring the last known is first.
         for val in ONOFFAUTO_OPTION_TO_API_VALUE.values():

--- a/custom_components/innotemp/sensor.py
+++ b/custom_components/innotemp/sensor.py
@@ -20,6 +20,7 @@ from .const import DOMAIN
 from .coordinator import InnotempDataUpdateCoordinator
 from .coordinator import InnotempCoordinatorEntity
 from .api_parser import (
+    coerce_api_int,
     strip_html,
     process_room_config_data,
     parse_var_enum_string,
@@ -362,19 +363,21 @@ class InnotempEnumSensor(InnotempCoordinatorEntity, SensorEntity):
         if api_value is None:
             return None
 
-        try:
-            # Ensure api_value is treated as an integer for dictionary lookup
-            selected_option = API_VALUE_TO_ONOFFAUTO_OPTION.get(int(api_value))
-            if selected_option is None:
-                _LOGGER.warning(
-                    f"InnotempEnumSensor.native_value: Unknown API value '{api_value}' for param_id {self._param_id} on entity {self.entity_id}. Not in {API_VALUE_TO_ONOFFAUTO_OPTION}"
-                )
-            return selected_option
-        except (ValueError, TypeError):
+        # Convert the API value to an int for the lookup. Values may arrive as
+        # "1", 1, or "1.0" (int("1.0") raises, which made the state unknown).
+        int_value = coerce_api_int(api_value)
+        if int_value is None:
             _LOGGER.warning(
                 f"InnotempEnumSensor.native_value: Could not convert API value '{api_value}' to int for param_id {self._param_id} on entity {self.entity_id}."
             )
             return None
+
+        selected_option = API_VALUE_TO_ONOFFAUTO_OPTION.get(int_value)
+        if selected_option is None:
+            _LOGGER.warning(
+                f"InnotempEnumSensor.native_value: Unknown API value '{api_value}' for param_id {self._param_id} on entity {self.entity_id}. Not in {API_VALUE_TO_ONOFFAUTO_OPTION}"
+            )
+        return selected_option
 
     # Ensure InnotempEnumSensor uses its _attr_device_class = SensorDeviceClass.ENUM
     # by NOT overriding the device_class property here. If this property method exists

--- a/custom_components/innotemp/switch.py
+++ b/custom_components/innotemp/switch.py
@@ -14,10 +14,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import InnotempDataUpdateCoordinator, InnotempCoordinatorEntity
 from .api_parser import (
+    coerce_api_int,
     strip_html,
     process_room_config_data,
-    API_VALUE_TO_ONOFF_OPTION,
-    ONOFF_OPTION_TO_API_VALUE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -176,8 +175,18 @@ class InnotempSwitch(InnotempCoordinatorEntity, SwitchEntity):
         if api_value is None:
             return None
 
-        # API value is expected to be "1" or "0" (as string) or possibly int
-        return str(api_value) == "1"
+        # The value arrives in mixed forms ("1", "1.0", 1, 1.0). A strict
+        # string compare against "1" misread "1.0" as off.
+        int_value = coerce_api_int(api_value)
+        if int_value is None:
+            _LOGGER.warning(
+                "Switch %s (%s): cannot interpret API value %r as on/off.",
+                self.entity_id,
+                self._param_id,
+                api_value,
+            )
+            return None
+        return int_value == 1
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
@@ -189,33 +198,12 @@ class InnotempSwitch(InnotempCoordinatorEntity, SwitchEntity):
 
     async def _send_switch_command(self, turn_on: bool) -> None:
         """Helper to send the turn on/off command."""
-        target_value_str = "1" if turn_on else "0"  # "1" for On, "0" for Off
+        val_new = "1" if turn_on else "0"
 
-        # We need the API value (often the same as what we deduced)
-        # Assuming ONOFF_OPTION_TO_API_VALUE maps "On" -> "1", "Off" -> "0"
-        # Let's verify mapping:
-        # API_VALUE_TO_ONOFF_OPTION: {"0": "Off", "1": "On"}
-        # ONOFF_OPTION_TO_API_VALUE: {"Off": "0", "On": "1"} (roughly)
-
-        # If we use ONOFF_OPTION_TO_API_VALUE:
-        target_option = "On" if turn_on else "Off"
-        # Need to find matching key in ONOFF_OPTION_TO_API_VALUE
-        # Since ONOFF_OPTION_TO_API_VALUE is constructed by reversing API_VALUE_TO_ONOFF_OPTION
-        # which has multiple keys for same value (0, 0.0), it might pick one.
-        # But for sending, "0" and "1" are safest for Innotemp usually.
-
-        # Let's use strict "0" and "1" as they are standard Innotemp boolean values.
-        val_new = target_value_str
-
-        # Previous value handling.
-        #
         # The controller uses ``val_prev`` for optimistic locking: a command is
         # only applied when ``val_prev`` matches the parameter's *current* value.
         # The current value must be read from the same var the entity displays
-        # (its own ``param_id``), exactly as ``is_on`` does. Previously this read
-        # the *mapped state var* from ``control_to_state_map`` which is a
-        # different (and often unpopulated) signal, so the first ``val_prev`` sent
-        # was a wrong guess and the device silently ignored the change.
+        # (its own ``param_id``), exactly as ``is_on`` does.
         previous_api_value: Any | None = None
         if self.coordinator.data:
             previous_api_value = self.coordinator.data.get(self._param_id)
@@ -230,9 +218,8 @@ class InnotempSwitch(InnotempCoordinatorEntity, SwitchEntity):
         if previous_api_value is not None:
             # Normalise to a clean "0"/"1" so the very first attempt carries the
             # correct previous value (SSE may deliver "1.0", 1, etc.).
-            val_prev_options.append(
-                "1" if str(previous_api_value) in ("1", "1.0") else "0"
-            )
+            prev_int = coerce_api_int(previous_api_value)
+            val_prev_options.append("1" if prev_int == 1 else "0")
 
         # Fallbacks: try both boolean states, then an empty val_prev.
         for val in ("0", "1"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
+import asyncio
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from aiohttp import ClientSession
 import json
 
@@ -111,13 +112,16 @@ async def test_retry_on_auth_error(mock_client_session):
     # 1. First command attempt -> redirect, indicating auth error
     mock_redirect_response = MagicMock()
     mock_redirect_response.status = 302
+    mock_redirect_response.text = AsyncMock(return_value="")
+    mock_redirect_response.headers = {"Location": "/login.php"}
     cm_redirect = AsyncMock()
     cm_redirect.__aenter__.return_value = mock_redirect_response
 
     # 2. Login attempt -> success
     mock_login_response = MagicMock()
     mock_login_response.status = 200
-    mock_login_response.json = AsyncMock(return_value={"info": "success"})
+    mock_login_response.text = AsyncMock(return_value=json.dumps({"info": "success"}))
+    mock_login_response.headers = {}
     cm_login = AsyncMock()
     cm_login.__aenter__.return_value = mock_login_response
 
@@ -147,3 +151,289 @@ async def test_retry_on_auth_error(mock_client_session):
     assert success is True
     assert mock_client_session.request.call_count == 2
     assert mock_client_session.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_login_redirect_raises_auth_error(mock_client_session):
+    """A redirect on login means the host/path is wrong; must not report success."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    configure_mock_response(
+        mock_client_session.post,
+        status=302,
+        text="",
+        headers={"Location": "https://mock_host/"},
+    )
+
+    with pytest.raises(InnotempAuthError):
+        await client.async_login()
+    assert client._is_logged_in is False
+
+
+@pytest.mark.asyncio
+async def test_login_non_json_response_raises_auth_error(mock_client_session):
+    """An HTML login page (not JSON) must raise instead of passing silently."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    configure_mock_response(
+        mock_client_session.post, text="<html><body>Login</body></html>"
+    )
+
+    with pytest.raises(InnotempAuthError):
+        await client.async_login()
+    assert client._is_logged_in is False
+
+
+@pytest.mark.asyncio
+async def test_login_empty_response_raises_auth_error(mock_client_session):
+    """An empty body on login must raise instead of passing silently."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    configure_mock_response(mock_client_session.post, text="")
+
+    with pytest.raises(InnotempAuthError):
+        await client.async_login()
+    assert client._is_logged_in is False
+
+
+@pytest.mark.asyncio
+async def test_login_warns_when_session_cookie_not_stored(mock_client_session, caplog):
+    """If the server sets a cookie but the jar drops it, a warning must be logged.
+
+    aiohttp's default CookieJar silently discards cookies from bare-IP hosts,
+    which previously made login look fine while everything after it failed.
+    """
+    client = InnotempApiClient(
+        mock_client_session, "192.168.1.50", "mock_user", "mock_password"
+    )
+    configure_mock_response(
+        mock_client_session.post,
+        json_data={"info": "success"},
+        headers={"Set-Cookie": "PHPSESSID=abc123; path=/"},
+    )
+    # Simulate an empty cookie jar (cookie was dropped).
+    mock_client_session.cookie_jar = iter(())
+
+    await client.async_login()
+
+    assert client._is_logged_in is True
+    assert any(
+        "cookie jar did not store it" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_command_sends_credentials_and_string_values(
+    mock_client_session,
+):
+    """The command payload must contain credentials and stringified values."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    client._is_logged_in = True
+    configure_mock_response(mock_client_session.request, json_data={"info": "success"})
+
+    success = await client.async_send_command(
+        room_id=3, param="003_e17par02_gui001out1", val_new=1, val_prev_options=[0]
+    )
+
+    assert success is True
+    call = mock_client_session.request.call_args
+    assert call.args[0] == "POST"
+    assert call.args[1].endswith("/value.save.php")
+    assert call.kwargs["data"] == {
+        "un": "mock_user",
+        "pw": "mock_password",
+        "room_id": "3",
+        "param": "003_e17par02_gui001out1",
+        "val_new": "1",
+        "val_prev": "0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_command_tries_fallback_prev_values(mock_client_session):
+    """A rejected val_prev must be retried with the next fallback value."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    client._is_logged_in = True
+
+    def make_cm(payload):
+        response = MagicMock()
+        response.status = 200
+        response.text = AsyncMock(return_value=json.dumps(payload))
+        response.headers = {}
+        response.raise_for_status = MagicMock()
+        cm = AsyncMock()
+        cm.__aenter__.return_value = response
+        return cm
+
+    mock_client_session.request.side_effect = [
+        make_cm({"info": "error", "error": "value mismatch"}),
+        make_cm({"info": "success"}),
+    ]
+
+    success = await client.async_send_command(
+        room_id=1, param="p1", val_new="1", val_prev_options=["0", None]
+    )
+
+    assert success is True
+    assert mock_client_session.request.call_count == 2
+    first, second = mock_client_session.request.call_args_list
+    assert first.kwargs["data"]["val_prev"] == "0"
+    # None fallback is sent as an empty string.
+    assert second.kwargs["data"]["val_prev"] == ""
+
+
+@pytest.mark.asyncio
+async def test_send_command_returns_false_when_all_prev_rejected(
+    mock_client_session,
+):
+    """If every val_prev attempt is rejected the command must report failure."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    client._is_logged_in = True
+    configure_mock_response(
+        mock_client_session.request,
+        json_data={"info": "error", "error": "value mismatch"},
+    )
+
+    success = await client.async_send_command(
+        room_id=1, param="p1", val_new="1", val_prev_options=["0", "1", None]
+    )
+
+    assert success is False
+    assert mock_client_session.request.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_send_command_handles_non_string_info(mock_client_session):
+    """A non-string 'info' field must not crash the success check."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    client._is_logged_in = True
+    configure_mock_response(mock_client_session.request, json_data={"info": None})
+
+    success = await client.async_send_command(
+        room_id=1, param="p1", val_new="1", val_prev_options=["0"]
+    )
+
+    assert success is False
+
+
+@pytest.mark.asyncio
+async def test_api_request_access_denied_payload_triggers_relogin(
+    mock_client_session,
+):
+    """An HTTP-200 'Access denied.' payload must trigger re-login and retry."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    client._is_logged_in = True
+
+    def make_cm(payload):
+        response = MagicMock()
+        response.status = 200
+        response.text = AsyncMock(return_value=json.dumps(payload))
+        response.headers = {}
+        response.raise_for_status = MagicMock()
+        cm = AsyncMock()
+        cm.__aenter__.return_value = response
+        return cm
+
+    mock_client_session.request.side_effect = [
+        make_cm({"info": "error", "error": "Access denied."}),
+        make_cm({"info": "success"}),
+    ]
+    mock_client_session.post.return_value = make_cm({"info": "success"})
+
+    success = await client.async_send_command(
+        room_id=1, param="p1", val_new="1", val_prev_options=["0"]
+    )
+
+    assert success is True
+    assert mock_client_session.request.call_count == 2
+    assert mock_client_session.post.call_count == 1
+
+
+async def _run_one_sse_iteration(client):
+    """Run one iteration of the SSE listener (the retry sleep is cancelled)."""
+    with patch(
+        "custom_components.innotemp.api.asyncio.sleep",
+        side_effect=asyncio.CancelledError,
+    ):
+        await client.async_sse_connect(MagicMock())
+        with pytest.raises(asyncio.CancelledError):
+            await client._sse_task
+    client._sse_task = None
+
+
+@pytest.mark.asyncio
+async def test_sse_redirect_marks_session_expired(mock_client_session):
+    """A redirected SSE request means the session is dead: force a re-login.
+
+    Previously the redirect was followed to the login page, the stream ended
+    with zero messages and the listener reconnected forever without ever
+    re-authenticating.
+    """
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    client._is_logged_in = True
+    client._signal_names_cache = ["sig1"]
+
+    mock_response = MagicMock()
+    mock_response.status = 302
+    mock_response.headers = {"Location": "/index.php"}
+    cm = AsyncMock()
+    cm.__aenter__.return_value = mock_response
+    mock_client_session.get.return_value = cm
+
+    await _run_one_sse_iteration(client)
+
+    assert client._is_logged_in is False
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_maps_values_to_signal_names(mock_client_session):
+    """SSE data lines must be zipped with the signal names and forwarded."""
+    client = InnotempApiClient(
+        mock_client_session, "mock_host", "mock_user", "mock_password"
+    )
+    client._is_logged_in = True
+    client._signal_names_cache = ["temp_top", "battery_soc"]
+
+    async def line_iter():
+        yield b": keep-alive\n"
+        yield b'data: [21.5, "88.0"]\n'
+
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.headers = {}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.content = line_iter()
+    cm = AsyncMock()
+    cm.__aenter__.return_value = mock_response
+    mock_client_session.get.return_value = cm
+
+    received = []
+    with patch(
+        "custom_components.innotemp.api.asyncio.sleep",
+        side_effect=asyncio.CancelledError,
+    ):
+        await client.async_sse_connect(received.append)
+        with pytest.raises(asyncio.CancelledError):
+            await client._sse_task
+    client._sse_task = None
+
+    assert received == [{"temp_top": 21.5, "battery_soc": "88.0"}]
+    # After a stream ends the client must re-authenticate before reconnecting.
+    assert client._is_logged_in is False

--- a/tests/test_api_parser.py
+++ b/tests/test_api_parser.py
@@ -628,3 +628,28 @@ def test_process_room_config_data(
                     assert res["numeric_room_id"] == 3
     elif expected_count == 0:
         assert not results  # Ensure results list is empty
+
+
+class TestCoerceApiInt:
+    """Tests for coerce_api_int, used by switch/select/enum-sensor lookups."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (1, 1),
+            ("1", 1),
+            (1.0, 1),
+            ("1.0", 1),  # SSE float-formatted string; int("1.0") raises
+            ("2.0", 2),
+            (" 0 ", 0),
+            (0.0, 0),
+            ("1.5", None),  # non-integral values are rejected, not truncated
+            ("garbage", None),
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_coerce_api_int(self, value, expected):
+        from custom_components.innotemp.api_parser import coerce_api_int
+
+        assert coerce_api_int(value) == expected

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -125,7 +125,171 @@ async def test_number_sends_numeric_room_id_and_updates_state(hass: HomeAssistan
     # Regression: previously this was "room3_param1" (the string var).
     assert kwargs["room_id"] == 3
     assert kwargs["param"] == param
-    assert kwargs["val_new"] == 21.0
+    # Integral floats are sent as plain ints (val_new=21, not 21.0), matching
+    # what the controller's own web UI sends.
+    assert kwargs["val_new"] == 21
     assert kwargs["val_prev_options"][0] == "18"
-    assert coordinator.data[param] == 21.0
+    assert coordinator.data[param] == 21
     assert number.native_value == 21.0
+
+
+def _make_switch(coordinator, param="room3_param1_entry1"):
+    switch = InnotempSwitch(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        3,
+        COMP,
+        param,
+        {"unit": "ONOFF", "var": param, "label": "Pump"},
+    )
+    switch.async_write_ha_state = MagicMock()
+    return switch
+
+
+@pytest.mark.parametrize(
+    ("api_value", "expected"),
+    [
+        ("1", True),
+        ("1.0", True),  # SSE delivers float-formatted strings
+        (1, True),
+        (1.0, True),
+        ("0", False),
+        ("0.0", False),
+        (0, False),
+        ("garbage", None),
+    ],
+)
+def test_switch_is_on_handles_mixed_value_formats(api_value, expected):
+    """``is_on`` must interpret "1.0"/1.0/1 all as on, not just "1"."""
+    param = "room3_param1_entry1"
+    coordinator = _make_coordinator({param: api_value})
+    switch = _make_switch(coordinator, param)
+    assert switch.is_on is expected
+
+
+@pytest.mark.asyncio
+async def test_switch_normalizes_float_prev_value(hass: HomeAssistant):
+    """A float-formatted current value must be normalised for val_prev."""
+    param = "room3_param1_entry1"
+    coordinator = _make_coordinator({param: "1.0"})  # currently ON, float format
+    switch = _make_switch(coordinator, param)
+
+    await switch.async_turn_off()
+
+    kwargs = coordinator.api_client.async_send_command.call_args.kwargs
+    assert kwargs["val_prev_options"][0] == "1"
+
+
+@pytest.mark.parametrize(
+    ("api_value", "expected"),
+    [
+        (1, "On"),
+        ("1", "On"),
+        ("2.0", "Auto"),  # SSE delivers float-formatted strings
+        (0.0, "Off"),
+        ("garbage", None),
+    ],
+)
+def test_select_current_option_handles_mixed_value_formats(
+    hass: HomeAssistant, api_value, expected
+):
+    """``current_option`` must handle "2.0"-style values (int() alone raises)."""
+    param = "room3_param1_e2"
+    coordinator = _make_coordinator({param: api_value})
+    select = InnotempInputSelect(
+        hass,
+        coordinator,
+        _config_entry(),
+        ROOM,
+        3,
+        COMP,
+        param,
+        {"unit": "ONOFFAUTO", "var": param, "label": "Mode"},
+    )
+    assert select.current_option == expected
+
+
+@pytest.mark.asyncio
+async def test_select_normalizes_float_prev_value(hass: HomeAssistant):
+    """A float-formatted current value must be sent as its int API form."""
+    param = "room3_param1_e2"
+    coordinator = _make_coordinator({param: "1.0"})  # currently On, float format
+    select = InnotempInputSelect(
+        hass,
+        coordinator,
+        _config_entry(),
+        ROOM,
+        3,
+        COMP,
+        param,
+        {"unit": "ONOFFAUTO", "var": param, "label": "Mode"},
+    )
+    select.async_write_ha_state = MagicMock()
+
+    await select.async_select_option("Auto")
+
+    kwargs = coordinator.api_client.async_send_command.call_args.kwargs
+    assert kwargs["val_prev_options"][0] == 1
+
+
+@pytest.mark.asyncio
+async def test_number_keeps_fractional_value_and_prev_fallbacks(
+    hass: HomeAssistant,
+):
+    """Fractional values are sent as-is; prev options include normalised form."""
+    param = "room3_param1_n1"
+    coordinator = _make_coordinator({param: "18.0"})
+    number = InnotempNumber(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        param,
+        {"unit": "°C", "var": param, "label": "Setpoint"},
+    )
+    number.async_write_ha_state = MagicMock()
+
+    await number.async_set_native_value(21.5)
+
+    kwargs = coordinator.api_client.async_send_command.call_args.kwargs
+    assert kwargs["val_new"] == 21.5
+    # Raw previous value first, then the int-normalised form, then the
+    # empty-string fallback.
+    assert kwargs["val_prev_options"] == ["18.0", "18", None]
+
+
+@pytest.mark.asyncio
+async def test_number_without_prev_value_still_sends_command(hass: HomeAssistant):
+    """With no known previous value only the empty fallback is offered."""
+    param = "room3_param1_n1"
+    coordinator = _make_coordinator({})
+    number = InnotempNumber(
+        coordinator,
+        _config_entry(),
+        ROOM,
+        COMP,
+        param,
+        {"unit": "°C", "var": param, "label": "Setpoint"},
+    )
+    number.async_write_ha_state = MagicMock()
+
+    await number.async_set_native_value(21.0)
+
+    kwargs = coordinator.api_client.async_send_command.call_args.kwargs
+    assert kwargs["val_prev_options"] == [None]
+
+
+@pytest.mark.asyncio
+async def test_switch_failed_command_does_not_update_state(hass: HomeAssistant):
+    """A rejected command must not optimistically flip the state."""
+    param = "room3_param1_entry1"
+    coordinator = _make_coordinator({param: "1"})
+    coordinator.api_client.async_send_command = AsyncMock(return_value=False)
+    switch = _make_switch(coordinator, param)
+
+    await switch.async_turn_off()
+
+    assert coordinator.data[param] == "1"
+    assert switch.is_on is True
+    switch.async_write_ha_state.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,127 @@
+"""Tests for integration setup and unload (custom_components/innotemp/__init__.py)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.innotemp.const import DOMAIN
+
+SAMPLE_CONFIG = {
+    "ROOMCONF": [
+        {
+            "@attributes": {"type": "room1", "var": "room1_var"},
+        }
+    ]
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_entry():
+    """Override the conftest autouse fixture: run the real async_setup_entry."""
+    yield
+
+
+def _make_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Innotemp Heating Controller",
+        data={
+            "host": "192.168.1.50",
+            "username": "user",
+            "password": "pass",
+        },
+        unique_id="innotemp_test",
+    )
+
+
+def _patch_api():
+    """Patch all network-touching API methods."""
+    return (
+        patch(
+            "custom_components.innotemp.InnotempApiClient.async_login",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.innotemp.InnotempApiClient.async_get_config",
+            new_callable=AsyncMock,
+            return_value=SAMPLE_CONFIG,
+        ),
+        patch(
+            "custom_components.innotemp.InnotempApiClient.async_sse_connect",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "custom_components.innotemp.InnotempApiClient.async_sse_disconnect",
+            new_callable=AsyncMock,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_and_unload_entry(hass: HomeAssistant):
+    """The entry must set up, store its data, and clean up fully on unload."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    p_login, p_config, p_connect, p_disconnect = _patch_api()
+    with p_login as mock_login, p_config, p_connect, p_disconnect as mock_disconnect:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.state is ConfigEntryState.LOADED
+        mock_login.assert_awaited()
+        data = hass.data[DOMAIN][entry.entry_id]
+        assert data["config"] == SAMPLE_CONFIG
+
+        # The session must keep cookies from IP hosts (PHPSESSID auth): the
+        # default "safe" jar silently drops them, breaking everything after
+        # login.
+        session = data["session"]
+        assert session.cookie_jar._unsafe is True
+
+        # Unload must stop the SSE listener, close the session and drop the
+        # stored data (previously there was no async_unload_entry at all and
+        # the SSE task leaked forever).
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.state is ConfigEntryState.NOT_LOADED
+        assert entry.entry_id not in hass.data[DOMAIN]
+        mock_disconnect.assert_awaited()
+        assert session.closed
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_aborts_on_login_failure(hass: HomeAssistant):
+    """A failing login must abort setup instead of half-initialising."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.innotemp.InnotempApiClient.async_login",
+        new_callable=AsyncMock,
+        side_effect=Exception("boom"),
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+@pytest.mark.asyncio
+async def test_setup_entry_aborts_on_invalid_host(hass: HomeAssistant):
+    """A stored host like 'http' must abort setup with a clear error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "http", "username": "user", "password": "pass"},
+        unique_id="innotemp_bad_host",
+    )
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR


### PR DESCRIPTION
Audit of the login and settings-write paths found several bugs; the most
important one explains why login "succeeds" but nothing afterwards works:

- Session cookie was silently dropped for IP hosts: the shared HA aiohttp
  session uses a default CookieJar (unsafe=False) which refuses cookies set
  by bare-IP hosts. The controller authenticates via a PHPSESSID cookie, so
  with an IP host every request after login (especially the SSE stream,
  which carries no credentials) was unauthenticated. Both setup and config
  flow now use a dedicated session with CookieJar(unsafe=True), and login
  logs a loud warning if the server sets a cookie the jar does not store.

- No async_unload_entry existed in __init__.py (an unused copy lived in
  config_flow.py, where HA never looks). Removing/reloading the integration
  leaked the SSE listener task forever and re-adding spawned a second one.
  Unload now stops the SSE task, shuts down the coordinator, closes the
  session and drops the entry data; the dead config_flow copy is removed.

- SSE listener could never recover from an expired session: the stream GET
  followed the redirect to the login page (HTTP 200, no data) and
  reconnected forever without re-authenticating. It now uses
  allow_redirects=False, treats redirects as auth errors, re-logins after
  any stream loss, and refetches signal names immediately on a
  names/values length mismatch instead of erroring on every message.

- Mixed value formats broke reads and writes: SSE delivers "1.0"-style
  strings, but switch.is_on compared str(value) == "1" (showing ON pumps
  as off) and select/enum-sensor used int(value), which raises on "1.0"
  (state unknown, wrong val_prev sent). A shared coerce_api_int() helper
  now normalises "1"/1/1.0/"1.0" everywhere, including the val_prev
  optimistic-locking values.

- number now sends integral values the way the web UI does (val_new=21,
  not 21.0) and offers the int-normalised previous value as a val_prev
  fallback; async_send_command no longer crashes on a non-string "info"
  field in the response.

Test coverage grows from 63 to 106 tests: login failure modes (redirect,
non-JSON, empty body), cookie-jar diagnostics, command payload contents,
val_prev fallback ladder and exhaustion, SSE redirect/re-login and
message-to-signal mapping, mixed-format value regressions for all three
control platforms, coerce_api_int, and full setup/unload lifecycle tests
including the unsafe-cookie-jar requirement. Also fixes the previously
failing test_retry_on_auth_error mock and re-formats with black.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016dHdXnVDQGEkdFybHdTXnV